### PR TITLE
More precise buglist URL

### DIFF
--- a/README
+++ b/README
@@ -163,7 +163,7 @@ URL's
   Please read the TODO file.
 
 - Buglist
-  https://bugs.kde.org
+  https://bugs.kde.org/describecomponents.cgi?product=krusader
 
 - A repository browser
   http://quickgit.kde.org/?p=krusader.git


### PR DESCRIPTION
I'm still baffled that krusader.org has been down for months. Most URLs in this README are broken.
